### PR TITLE
Set definitions for pointers to 32-bit width int

### DIFF
--- a/include/bits/stdint.h
+++ b/include/bits/stdint.h
@@ -55,9 +55,18 @@ typedef __UINTMAX_TYPE__ uintmax_t;
 #define UINT_FAST16_MAX UINT32_MAX
 #define UINT_FAST32_MAX UINT32_MAX
 
+#ifdef EOSIO_NATIVE
 #define INTPTR_MIN      INT64_MIN
 #define INTPTR_MAX      INT64_MAX
 #define UINTPTR_MAX     UINT64_MAX
 #define PTRDIFF_MIN     INT64_MIN
 #define PTRDIFF_MAX     INT64_MAX
 #define SIZE_MAX        UINT64_MAX
+#else
+#define INTPTR_MIN      INT32_MIN
+#define INTPTR_MAX      INT32_MAX
+#define UINTPTR_MAX     UINT32_MAX
+#define PTRDIFF_MIN     INT32_MIN
+#define PTRDIFF_MAX     INT32_MAX
+#define SIZE_MAX        UINT32_MAX
+#endif


### PR DESCRIPTION
EOSIO uses wasm32 and definitions for pointers and size_t should be 32-bit width integers.